### PR TITLE
Update deployment.yaml

### DIFF
--- a/charts/invoiceninja/templates/deployment.yaml
+++ b/charts/invoiceninja/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               [[ -z "${DB_HOST1}" ]] || DB_HOST="${DB_HOST1}";
               [[ -z "${DB_PORT1}" ]] || DB_PORT="${DB_PORT1}";
               while [ $COUNTER -lt 120 ]; do
-                if mysqladmin ping -h "$DB_HOST" -P $DB_PORT --silent; then
+                if mysqladmin ping -h "$DB_HOST" -P $DB_PORT --connect-timeout=15 --silent; then
                   exit 0;
                 fi;
                 let COUNTER=COUNTER+1;


### PR DESCRIPTION
Changed init-container "wait-db" for waiting 15 seconds instead of 12 hours (default) in case of a timeout. This might happen in case of istio installations as envoy proxy is missing while realizing strict mTLS. For istio enabled environments, container must be removed instead.
The timeout enables finding the error after 15 seconds instead of 12 hours.